### PR TITLE
Add prop to allow absolute links

### DIFF
--- a/src/website/WebsiteFooter.tsx
+++ b/src/website/WebsiteFooter.tsx
@@ -140,7 +140,14 @@ const FooterSection = styled.div`
   }
 `
 
-const WebsiteFooter = ({ newsletterComponent }: any) => (
+type WebsiteFooterProps = React.PropsWithoutRef<{
+  /** Should the internal links be absolute or relative */
+  absoluteLinks?: boolean
+
+  newsletterComponent: any
+}>
+
+const WebsiteFooter = ({ newsletterComponent, absoluteLinks = false }: WebsiteFooterProps) => (
   <FooterSection>
     <div className="column one">
       <img
@@ -154,14 +161,14 @@ const WebsiteFooter = ({ newsletterComponent }: any) => (
         <h3 className="header">Products</h3>
         <a
           className="link"
-          href="/client"
+          href={`${absoluteLinks ? 'https://www.prisma.io' : ''}/client`}
         >
           Prisma Client
         </a>
-        <a className="link" href="/migrate">
+        <a className="link" href={`${absoluteLinks ? 'https://www.prisma.io' : ''}/migrate`}>
           Prisma Migrate
         </a>
-        <a className="link" href="/studio">
+        <a className="link" href={`${absoluteLinks ? 'https://www.prisma.io' : ''}/studio`}>
           Prisma Studio
         </a>
         <a className="link" href="https://app.prisma.io/login">
@@ -173,18 +180,18 @@ const WebsiteFooter = ({ newsletterComponent }: any) => (
       </div>
       <div className="group">
         <h3 className="header">Resources</h3>
-        <a className="link" href="/docs/">
+        <a className="link" href={`${absoluteLinks ? 'https://www.prisma.io' : ''}/docs/`}>
           Docs
         </a>
         <a
           className="link"
-          href="/docs/getting-started/quickstart-typescript"
+          href={`${absoluteLinks ? 'https://www.prisma.io' : ''}/docs/getting-started/quickstart-typescript`}
         >
           Get Started
         </a>
         <a
           className="link"
-          href="/docs/reference/api-reference/prisma-client-reference"
+          href={`${absoluteLinks ? 'https://www.prisma.io' : ''}/docs/reference/api-reference/prisma-client-reference`}
         >
           API Reference
         </a>
@@ -194,28 +201,28 @@ const WebsiteFooter = ({ newsletterComponent }: any) => (
         <a className="link" href="https://www.howtographql.com/">
           How to GraphQL
         </a>
-        <a className="link" href="/dataguide/">
+        <a className="link" href={`${absoluteLinks ? 'https://www.prisma.io' : ''}/dataguide/`}>
           Data Guide
         </a>
       </div>
       <div className="group">
         <h3 className="header">Prisma With</h3>
-        <a className="link" href="/nextjs">
+        <a className="link" href={`${absoluteLinks ? 'https://www.prisma.io' : ''}/nextjs`}>
           Prisma with Next.js
         </a>
-        <a className="link" href="/graphql">
+        <a className="link" href={`${absoluteLinks ? 'https://www.prisma.io' : ''}/graphql`}>
           Prisma with GraphQL
         </a>
-        <a className="link" href="/apollo">
+        <a className="link" href={`${absoluteLinks ? 'https://www.prisma.io' : ''}/apollo`}>
           Prisma with Apollo
         </a>
-        <a className="link" href="/nestjs">
+        <a className="link" href={`${absoluteLinks ? 'https://www.prisma.io' : ''}/nestjs`}>
           Prisma with NestJS
         </a>
-        <a className="link" href="/express">
+        <a className="link" href={`${absoluteLinks ? 'https://www.prisma.io' : ''}/express`}>
           Prisma with Express
         </a>
-        <a className="link" href="/hapi">
+        <a className="link" href={`${absoluteLinks ? 'https://www.prisma.io' : ''}/hapi`}>
           Prisma with hapi
         </a>
       </div>
@@ -223,7 +230,7 @@ const WebsiteFooter = ({ newsletterComponent }: any) => (
     <div className="column three">
       <div className="group">
         <h3 className="header">Community</h3>
-        <a className="link" href="/community">
+        <a className="link" href={`${absoluteLinks ? 'https://www.prisma.io' : ''}/community`}>
           Meet the Community
         </a>
         <a className="link" href="https://slack.prisma.io/">
@@ -252,10 +259,10 @@ const WebsiteFooter = ({ newsletterComponent }: any) => (
       </div>
       <div className="group">
         <h3 className="header">Company</h3>
-        <a className="link" href="/about">
+        <a className="link" href={`${absoluteLinks ? 'https://www.prisma.io' : ''}/about`}>
           About
         </a>
-        <a className="link jobs" href="/jobs">
+        <a className="link jobs" href={`${absoluteLinks ? 'https://www.prisma.io' : ''}/jobs`}>
           Jobs <span className="tag">We're hiring!</span>
         </a>
         <a
@@ -264,13 +271,13 @@ const WebsiteFooter = ({ newsletterComponent }: any) => (
         >
           Causes
         </a>
-        <a className="link" href="/blog/">
+        <a className="link" href={`${absoluteLinks ? 'https://www.prisma.io' : ''}/blog/`}>
           Blog
         </a>
         <a className="link" href="https://pris.ly/privacy">
           Terms & Privacy
         </a>
-        <a className="link" href="/sitemap">
+        <a className="link" href={`${absoluteLinks ? 'https://www.prisma.io' : ''}/sitemap`}>
           HTML Sitemap
         </a>
       </div>

--- a/src/website/WebsiteHeader.tsx
+++ b/src/website/WebsiteHeader.tsx
@@ -221,7 +221,7 @@ const HeaderWrapper = styled.div`
 `
 
 type NavigationLinkProps = React.PropsWithoutRef<{
-  /** An identifying icon */
+  /** Should the internal links be absolute or relative */
   absoluteLinks?: boolean
 }>
 

--- a/src/website/WebsiteHeader.tsx
+++ b/src/website/WebsiteHeader.tsx
@@ -33,15 +33,15 @@ const NavLinksWrapper = styled.div`
     }
   }
 `
-const NavLinks = () => (
+const NavLinks = ({ absoluteLinks = false }: NavigationLinkProps) => (
   <NavLinksWrapper>
-    <a href="/docs/getting-started/quickstart-typescript">
+    <a href={`${absoluteLinks ? 'https://www.prisma.io' : ''}/docs/getting-started/quickstart-typescript`}>
       Quickstart
     </a>
-    <a href="/docs/">Docs</a>
-    <a href="/docs/about/faq">FAQ</a>
-    <a href="/community">Community</a>
-    <a href="/blog/">Blog</a>
+    <a href={`${absoluteLinks ? 'https://www.prisma.io' : ''}/docs/`}>Docs</a>
+    <a href={`${absoluteLinks ? 'https://www.prisma.io' : ''}/docs/about/faq`}>FAQ</a>
+    <a href={`${absoluteLinks ? 'https://www.prisma.io' : ''}/community`}>Community</a>
+    <a href={`${absoluteLinks ? 'https://www.prisma.io' : ''}/blog/`}>Blog</a>
     <a href="https://github.com/prisma" className="github">
       GitHub
     </a>
@@ -181,7 +181,7 @@ const NavWrapper = styled.nav`
     }
   }
 `
-const Nav = () => (
+const Nav = ({ absoluteLinks }: NavigationLinkProps) => (
   <NavWrapper>
     <a href="/">
       <svg
@@ -201,7 +201,7 @@ const Nav = () => (
       </svg>
     </a>
     <div className="menu">
-      <NavLinks />
+      <NavLinks absoluteLinks={absoluteLinks} />
       <a href="https://github.com/prisma/prisma" className="github">
         <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
           <path
@@ -219,9 +219,15 @@ const HeaderWrapper = styled.div`
   padding: 0 ${theme.space[16]};
   display: flex;
 `
-const WebsiteHeader = () => (
+
+type NavigationLinkProps = React.PropsWithoutRef<{
+  /** An identifying icon */
+  absoluteLinks?: boolean
+}>
+
+const WebsiteHeader = ({ absoluteLinks = false }: NavigationLinkProps) => (
   <HeaderWrapper>
-    <Nav />
+    <Nav absoluteLinks={absoluteLinks} />
     <MobileNav />
   </HeaderWrapper>
 )


### PR DESCRIPTION
This is to allow us to use the header and footer in preview deployments without breaking the URLs in the header and footer