### PR TITLE
Remove margins from buttons

### DIFF
--- a/src/components/button-group/ButtonGroup.tsx
+++ b/src/components/button-group/ButtonGroup.tsx
@@ -12,7 +12,7 @@ export function ButtonGroup({ children }: ButtonGroupProps) {
 
   if (buttons.length === 1 || buttons.length === 2) {
     return (
-      <section className="flex flex-grow">
+      <section className="flex flex-grow space-x-4">
         {buttons.length === 1 && children}
         {buttons.length === 2 && children}
       </section>
@@ -20,7 +20,7 @@ export function ButtonGroup({ children }: ButtonGroupProps) {
   } else {
     return (
       <section className="flex flex-grow justify-between">
-        <div className="flex">
+        <div className="flex space-x-4">
           {buttons[0]}
           {buttons[1]}
         </div>

--- a/src/components/button/Button.stories.tsx
+++ b/src/components/button/Button.stories.tsx
@@ -4,38 +4,38 @@ import { Button } from "./Button"
 
 storiesOf("Lens/Button", module)
   .add("Primary variant", () => (
-    <>
+    <div className="flex space-x-4">
       <Button onPress={action("onPress")}>Primary</Button>
       <Button isDisabled>Disabled</Button>
-    </>
+    </div>
   ))
   .add("Secondary variant", () => (
-    <>
+    <div className="flex space-x-4">
       <Button onPress={action("onPress")} variant="secondary">
         Secondary
       </Button>
       <Button variant="secondary" isDisabled>
         Disabled
       </Button>
-    </>
+    </div>
   ))
   .add("Quiet variant", () => (
-    <>
+    <div className="flex space-x-4">
       <Button onPress={action("onPress")} variant="quiet">
         Button
       </Button>
       <Button variant="quiet" isDisabled>
         Disabled
       </Button>
-    </>
+    </div>
   ))
   .add("Link variant", () => (
-    <>
+    <div className="flex space-x-4">
       <Button onPress={action("onPress")} variant="link">
         Button
       </Button>
       <Button variant="link" isDisabled>
         Disabled
       </Button>
-    </>
+    </div>
   ))

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -44,7 +44,7 @@ function Button(
         ref={ref}
         {...mergeProps(buttonProps, hoverProps)}
         className={cn(
-          "flex justify-center px-3 py-1.5 m-2",
+          "flex justify-center px-3 py-1.5",
           "rounded-md",
           "text-sm whitespace-nowrap",
           {
@@ -52,7 +52,8 @@ function Button(
           },
           {
             "font-bold bg-gray-700 text-white": variant === "primary",
-            "font-bold text-gray-400": variant === "primary" && isDisabled,
+            "font-bold bg-gray-500 text-white":
+              variant === "primary" && isDisabled,
             "bg-gray-800": variant === "primary" && isHovered,
             "bg-gray-900": variant === "primary" && isPressed,
           },
@@ -70,7 +71,7 @@ function Button(
           },
           {
             "underline text-gray-600 dark:text-gray-400": variant === "link",
-            "text-gray-200 dark:text-gray-600":
+            "text-gray-400 dark:text-gray-600":
               variant === "link" && isDisabled,
             "text-gray-700 dark:text-gray-500": variant === "link" && isHovered,
             "text-gray-800 dark:text-gray-600": variant === "link" && isPressed,

--- a/src/components/card/Card.tsx
+++ b/src/components/card/Card.tsx
@@ -36,8 +36,8 @@ export function Card({
     >
       {(icon || title) && (
         <section className="flex items-center">
-          {icon && <Icon name={icon} size="md"></Icon>}
-          {title && <Title className="ml-6">{title}</Title>}
+          {icon && <Icon name={icon} size="md" className="mr-6"></Icon>}
+          {title && <Title>{title}</Title>}
         </section>
       )}
       <section>{children}</section>


### PR DESCRIPTION
Pretty big change if you think about consequences, but I think this is the right thing to do.

It's easy to add margin outside Lens, but not to take it away.

Having margins as part of the button messes up some layouts (on Cloud)