### PR TITLE
Add right aligned link to infocard component

### DIFF
--- a/src/components/info-card/InfoCard.stories.tsx
+++ b/src/components/info-card/InfoCard.stories.tsx
@@ -4,7 +4,15 @@ import { InfoCard } from "./InfoCard"
 storiesOf("Lens/InfoCard", module).add("Default", () => (
   <section className="w-96">
     {/* InfoCards fill their parent by default. This `section` only exists to make the story look better */}
-    <InfoCard.Container icon="database" title="Maroon Copper Jasmine">
+
+    <InfoCard.Container
+      icon="database"
+      title="Maroon Copper Jasmine"
+      link={{
+        href: "/?path=/story/welcome--page",
+        children: "welcome",
+      }}
+    >
       <InfoCard.Row label="Provider">PlanetScale</InfoCard.Row>
       <InfoCard.Row label="Region">EU_WEST_1</InfoCard.Row>
       <InfoCard.Row label="RAM">4GB</InfoCard.Row>

--- a/src/components/info-card/InfoCard.tsx
+++ b/src/components/info-card/InfoCard.tsx
@@ -4,6 +4,7 @@ import { Card } from "../card/Card"
 import { Icon } from "../icon/Icon"
 import { Title } from "../../typography/title/Title"
 import { Label } from "../label/Label"
+import { Link, LinkProps } from "../link/Link"
 
 export type InfoCardContainerProps = React.PropsWithChildren<{
   /** An identifying icon */
@@ -14,6 +15,8 @@ export type InfoCardContainerProps = React.PropsWithChildren<{
   width?: number
   /** If provided, fixes the Card's width */
   height?: number
+  /** If provided, adds a right aligned link to the Card's title row */
+  link?: LinkProps
 }>
 
 /** An InfoCard displays */
@@ -22,6 +25,7 @@ function InfoCardContainer({
   title,
   width,
   height,
+  link,
   children,
 }: InfoCardContainerProps) {
   return (
@@ -29,8 +33,12 @@ function InfoCardContainer({
       <section className="flex items-center px-6 py-4">
         {icon && <Icon name={icon} size="md"></Icon>}
         {title && <Title className="ml-6">{title}</Title>}
+        {link && (
+          <span className="ml-auto">
+            <Link {...link} />
+          </span>
+        )}
       </section>
-
       {children}
     </Card>
   )


### PR DESCRIPTION
This PR adds an optional right aligned link to the info card component. 
Necessary for https://github.com/prisma/cloud/issues/185

<img width="1098" alt="Screenshot 2021-04-12 at 10 04 48" src="https://user-images.githubusercontent.com/55739812/114361543-87b27d80-9b76-11eb-92d7-d49902d6339f.png">
