### PR TITLE
Chnaged quickstart link in header

### DIFF
--- a/src/website/WebsiteHeader.tsx
+++ b/src/website/WebsiteHeader.tsx
@@ -36,9 +36,8 @@ const NavLinksWrapper = styled.div`
 const NavLinks = ({ absoluteLinks = false }: NavigationLinkProps) => (
   <NavLinksWrapper>
     <a
-      href={`${
-        absoluteLinks ? "https://www.prisma.io" : ""
-      }/docs/getting-started/quickstart-typescript`}
+      href={`${absoluteLinks ? "https://www.prisma.io" : ""
+        }/docs/getting-started/quickstart`}
     >
       Quickstart
     </a>


### PR DESCRIPTION
This PR changes the link to the Quickstart guide in the main header