### PR TITLE
fix: Display toasts at top of screen by default

### DIFF
--- a/src/components/toast/ToastContainer.tsx
+++ b/src/components/toast/ToastContainer.tsx
@@ -12,7 +12,7 @@ export function ToastContainer() {
   return (
     <div
       className={cn(
-        "fixed bottom-8 left-0 right-0",
+        "fixed top-20 left-0 right-0",
         "flex flex-col items-center"
       )}
     >


### PR DESCRIPTION
Part 1 of #89

This PR moves the lens toasts to the top of the page by default. 