### PR TITLE
fix: Menu anchor prop for conditional menu body placement

### DIFF
--- a/src/components/menu/Menu.stories.tsx
+++ b/src/components/menu/Menu.stories.tsx
@@ -75,7 +75,7 @@ export const AnchoredLeftWithStaticData = () => (
 
       <Menu.Body
         title="Project Actions"
-        anchor='left'
+        anchor="left"
         onSelectionChange={action("onSelectionChange")}
       >
         <Menu.Option key="handle">ALongUserHandle</Menu.Option>
@@ -96,7 +96,7 @@ export const AnchoredRightWithStaticData = () => (
 
       <Menu.Body
         title="Project Actions"
-        anchor='right'
+        anchor="right"
         onSelectionChange={action("onSelectionChange")}
       >
         <Menu.Option key="handle">ALongUserHandle</Menu.Option>

--- a/src/components/menu/Menu.stories.tsx
+++ b/src/components/menu/Menu.stories.tsx
@@ -65,3 +65,45 @@ export const WithSectionsAndStaticData = () => (
     </Menu.Body>
   </Menu.Container>
 )
+
+export const AnchoredLeftWithStaticData = () => (
+  <div className="flex justify-center">
+    <Menu.Container>
+      <Button variant="quiet">
+        <Icon name="sliders" />
+      </Button>
+
+      <Menu.Body
+        title="Project Actions"
+        anchor='left'
+        onSelectionChange={action("onSelectionChange")}
+      >
+        <Menu.Option key="handle">ALongUserHandle</Menu.Option>
+        <Menu.Option key="edit">Edit</Menu.Option>
+        <Menu.Option key="invite">Invite</Menu.Option>
+        <Menu.Option key="delete">Delete</Menu.Option>
+      </Menu.Body>
+    </Menu.Container>
+  </div>
+)
+
+export const AnchoredRightWithStaticData = () => (
+  <div className="flex justify-center">
+    <Menu.Container>
+      <Button variant="quiet">
+        <Icon name="sliders" />
+      </Button>
+
+      <Menu.Body
+        title="Project Actions"
+        anchor='right'
+        onSelectionChange={action("onSelectionChange")}
+      >
+        <Menu.Option key="handle">ALongUserHandle</Menu.Option>
+        <Menu.Option key="edit">Edit</Menu.Option>
+        <Menu.Option key="invite">Invite</Menu.Option>
+        <Menu.Option key="delete">Delete</Menu.Option>
+      </Menu.Body>
+    </Menu.Container>
+  </div>
+)

--- a/src/components/menu/Menu.tsx
+++ b/src/components/menu/Menu.tsx
@@ -100,6 +100,8 @@ export type MenuBodyProps<OptionKey extends string> = {
   children: CollectionChildren<MenuOption<OptionKey>>
   /** A string describing what this Menu represents */
   title: string
+  /** Options for a user to anchor the menu  */
+  anchor?: "left" | "right"
   /** Callback invoked when the Menu's selection changes */
   onSelectionChange?: (key: OptionKey) => void
 }
@@ -111,6 +113,7 @@ function MenuBody<OptionKey extends string>({
   id,
   children,
   title,
+  anchor,
   onSelectionChange,
 }: MenuBodyProps<OptionKey>) {
   const context = useContext(MenuContext)
@@ -144,6 +147,32 @@ function MenuBody<OptionKey extends string>({
   })
   // Figure out trigger dimensions so we can size the overlay
   const triggerDimensions = context.triggerRef.current?.getBoundingClientRect()
+  // Useful for anchoring calculations
+  const overlayDimensions = overlayRef.current?.getBoundingClientRect()
+
+  /** Override the overlay positioning if an anchor is provided
+   * default to center alignment
+  */
+  let leftPositioning = null
+  if (triggerDimensions && overlayDimensions) {
+    leftPositioning =
+      anchor === "left"
+        ? triggerDimensions?.x
+        : anchor === "right"
+        ? triggerDimensions?.x -
+          (overlayDimensions?.width - triggerDimensions?.width)
+        : triggerDimensions?.x -
+          (overlayDimensions?.width - triggerDimensions?.width) / 2
+  }
+
+  const menuBodyStyles = {
+    ...positionProps.style,
+    minWidth: triggerDimensions?.width,
+  }
+
+  if (leftPositioning) {
+    menuBodyStyles['left'] = leftPositioning
+  }
 
   return (
     <OverlayContainer>
@@ -151,11 +180,7 @@ function MenuBody<OptionKey extends string>({
         lens-role="menu-body"
         ref={overlayRef}
         {...mergeProps(positionProps, overlayProps)}
-        style={{
-          ...positionProps.style,
-          left: triggerDimensions?.left,
-          minWidth: triggerDimensions?.width,
-        }}
+        style={menuBodyStyles}
       >
         <DismissButton onDismiss={context.close} />
         <ul

--- a/src/components/menu/Menu.tsx
+++ b/src/components/menu/Menu.tsx
@@ -152,7 +152,7 @@ function MenuBody<OptionKey extends string>({
 
   /** Override the overlay positioning if an anchor is provided
    * default to center alignment
-  */
+   */
   let leftPositioning = null
   if (triggerDimensions && overlayDimensions) {
     leftPositioning =
@@ -171,7 +171,7 @@ function MenuBody<OptionKey extends string>({
   }
 
   if (leftPositioning) {
-    menuBodyStyles['left'] = leftPositioning
+    menuBodyStyles["left"] = leftPositioning
   }
 
   return (


### PR DESCRIPTION
This update is in relation to issue 717 on prisma/studio, shaking-UI.

Local testing showed that without the menu being directionally anchored, lengthy Item values within the menu body causes the Menu Body to render off view port.

This PR adds anchoring to the menuOverlay relative to the menuTrigger in order to address the off screen rendering.